### PR TITLE
Add calendars/index.yaml file: metadata for the index list

### DIFF
--- a/calendars/_config.yaml
+++ b/calendars/_config.yaml
@@ -1,0 +1,5 @@
+title: git-calendar sample calendars
+description: |
+  This is a description of the calendars.  It can be edited in
+  calendars/index.yaml <b>text</b>
+

--- a/git_calendar/build.py
+++ b/git_calendar/build.py
@@ -16,7 +16,7 @@ TEMPLATE_DIR = Path(__file__).parent/'templates'
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser()
-    parser.add_argument('inputs', nargs='+', help="input files")
+    parser.add_argument('inputs', nargs='+', help="input files", type=Path)
     parser.add_argument('--output', '-o', help="output directory", type=str)
     parser.add_argument('--index', '-i', help="output index file", type=str)
     parser.add_argument('--timezone', action='append', help="zoneinfo timezone names", type=str, default=[])
@@ -25,12 +25,17 @@ def main(argv=sys.argv[1:]):
 
     calendars = [ ]
     timezones = [ ]
+    config = None
     for timezone in args.timezone:
         timezones.append({'tz': timezone, 'tzslug': timezone.replace('/', '-')})
     if not os.path.exists(args.output):
         os.mkdir(args.output)
 
     for f in args.inputs:
+        if f.stem == '_config':
+            print(f"processing config metadata {f}", file=sys.stderr)
+            config = yaml.safe_load(open(f))
+            continue
         print(f"processing {f}", file=sys.stderr)
         calendar = { }
         calendar['data'] = yaml.safe_load(open(f))
@@ -67,7 +72,8 @@ def main(argv=sys.argv[1:]):
             timezones=timezones,
             timestamp=timestamp,
             git_hash=git_hash,
-            edit_link=args.edit_link
+            edit_link=args.edit_link,
+            config=config,
             )
         shutil.copy(TEMPLATE_DIR/'style.css', Path(args.index).parent/'style.css')
         open(args.index, 'w').write(index)

--- a/git_calendar/templates/index.html.j2
+++ b/git_calendar/templates/index.html.j2
@@ -12,11 +12,24 @@
 
     <link href="css/style.css" rel="stylesheet">
 
-    <title>{{ title or 'Calendars'}}</title>
+    <title>{{ config.title or 'Calendars'}}</title>
   </head>
 
   <body>
     <div class="container">
+      {% if config %}
+
+      {% if config.title %}<h2>{{config.title}}</h2>{% endif %}
+
+      {% if config.description %}
+      <p>
+	{{ config.description }}
+      </p>
+      {% endif %}
+
+      {% endif %}
+
+
       <h2>Available calendars</h2>
       <ul>
 	{% for c in calendars if not c.base == 'example'%}


### PR DESCRIPTION
- A file named index.yaml can be provided, which is not a calendar but
  contains metadata that can be used in the index.html template file.
  So far, this can be used to set the title and add a description
  above the calendar list.  This is useful to make the page look a bit
  more professional.
- The file is currently hardcoded to the name index.yaml, which I
  guess is OK since index is commonly used for indexes.
- A bit more questionable is that it is in calendars/index.yaml (as
  in, mixed in with the other calendars).  Perhaps this makes sense if
  this is seen as "data".  The practial use is that other consumers
  don't need to change their build.sh to add in new command line
  arguments.
  - Basically, when reading the calendar files, if something is named
    `index.*`, treat this as the metadata.
- Add a sample index.yaml file.
- Review: is there anything very off here?  Anyway, it can be iterated
