### PR TITLE
Handle URLs properly

### DIFF
--- a/calendars/test-include.yaml
+++ b/calendars/test-include.yaml
@@ -4,3 +4,4 @@ timezone: Europe/Helsinki
 include:
   - 'example.yaml'
   - 'https://coderefinery.github.io/calendar/workshops.ics'
+  - 'https://enccs.se/events-at-enccs/list/?shortcode=5210815c&ical=1'


### PR DESCRIPTION
This update downloads the ics calendars (also from urls which are not ending in ics (quite common e.g. enccs), determines file extensions from the headers (or filename if no headers provided) and adds the events. 
With a little more code, additional file types from URLs can be added easily. 