### PR TITLE
Big revision, add Github ACtion

### DIFF
--- a/.github/workflows/calendar.yml
+++ b/.github/workflows/calendar.yml
@@ -29,7 +29,7 @@ jobs:
           pip install -r requirements.txt
       - name: build
         run: |
-          ./build.sh "--edit-link=https://github.com/$GITHUB_REPOSITORY"
+          git-calendar calendars/*.yaml out/ --edit-link=https://github.com/$GITHUB_REPOSITORY
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == env.DEFAULT_BRANCH }}

--- a/README.md
+++ b/README.md
@@ -1,70 +1,128 @@
-# yaml to ics calendar
+# YAML to ics calendar
 
-This repository turns yaml files into icl calendars (importable into
+This repository turns yaml files into .ics calendars (importable into
 different programs) using
 [yaml2ics](https://github.com/scientific-python/yaml2ics) and GitHub
-actions.
+actions.  Or, you can use git-calendar directly.
 
 This repository provides a working template for the action to build +
-publish to Github Pages, and some minimal HTML index pages.  All of
-the important logic is in
+publish to Github Pages, including files into other files, and some
+minimal HTML index pages.  All of the important logic is in
 [yaml2ics](https://github.com/scientific-python/yaml2ics), so if you
 want to roll your own site and build system (which isn't hard) for the
 .ics files, consider using yaml2ics directly.
 
-This is sort of alpha: it works and is used, but code editing or
-asking for clarifications is probably needed.  Documentation should be
-improved.
 
 
-
-## Example
+## Example deployments
 
 The CodeRefinery calendar
 * [Built calendar site](https://coderefinery.github.io/calendar/)
-  (main landing page for most projects)
+  (the auto-generated landing page)
 * [Source repository](https://github.com/coderefinery/calendar)
 * Optional: [Calendars inserted into
   website](https://coderefinery.org/calendars/) ([source](https://github.com/coderefinery/coderefinery.org/blob/main/content/calendars.md))
 
 
 
-## Usage
+## General principles
 
-To use, look at
-[git-calendar-template](https://github.com/coderefinery/git-calendar-template)
-for a sample repository that uses this.  Generate your own repository
-from that template and go from there.
+One defines events in YAML, and they get built to `.ics` files which
+can be served as a static site.  These can then be imported to various
+calendar clients.
 
-This repository can also be installed as a Python pip package.
+There's a command line program, `git-calendar`, which takes YAML files
+as input (one of which can be named `_config.yaml`).  The last
+argument is the output directory to which to write.
 
-Usage in short:
+A typical repository layout:
 
 - `calendars/*.yaml` contains the input calendars.
-- `./build.sh` builds the outputs.  Edit this script as
-  needed, or copy the command to your own build script.
-  - `out/index.html` gets build and serves as a landing page
-  - Calendars get build to `out/*.ics`
-  - The Github Actions workflow file deploys `out/` to the `gh-pages`
-  branch.
-
-- **First time deployment note:** you have to go to settings and
-  toggle pages off and on again the first time to enable Github Pages,
-  after that Github Actions will automatically deploy.
+- `output/` is the web root for web deployment
+- `output/*.ics` is the build calendars
+- `output/index.html` gets built and serves as a landing page with
+  links to the .ics files
 
 For now, see `calendars/example.yaml` for an example, or any of the
 test calendars in yaml2ics.  This documentation should be improved.
 
 
 
+## Usage - Github action
+
+This can be used as Github action (see EXAMPLE REPO for the full file).
+
+```yaml
+      - uses: actions/checkout@v4
+      - name: git-calendar action
+        uses: coderefinery/git-calendar@action-test
+        with:
+          input_dir: calendars    # the default, not required
+          output_dir: output      # the default, not required
+          index_file: index.html  # the default, set to '' to not
+        create
+        htmlbody_file: body.html  # Only the part inside <body> for inclusion in other files
+```
+
+This action will automatically deploy to Github Pages.  You can set
+`with: pages_deploy: false` to disable this.  The action will also
+setup Python and install this Python library.  If you already set up
+Python, it may be easier to code up your own action than use this.
+
+
+
+## Usage - Raw Github action
+
+If you want to program the action yourself, below is the base.  You
+probably can probably figure out how to integrate this to a Github
+Pages deployment and all.
+```yaml
+    - name: build
+      shell: bash
+      run: |
+        git-calendar calendars/*.yaml output/ --index=index.html --edit-link=https://github.com/$GITHUB_REPOSITORY
+```
+
+
+
+## Usage - command line
+
+This is a Python package, install as normal (yes, in a virtual environment, etc...):
+```console
+$ pip install git-calendar
+```
+
+Then run:
+
+```console
+$ git-calendar calendars/*.yaml output/ --index=index.html --edit-link=https://github.com/$GITHUB_REPOSITORY
+```
+
+There are more options, not currently documented.
+
+
+
+## Usage - via raw yaml2ics
+
+Don't forget this is just a wrapper around
+[yaml2ics](https://github.com/scientific-python/yaml2ics) - if you
+only need a .ics file and not index.html, including calendars in
+others, etc., then maybe that is your starting point:
+
+```console
+$ python yaml2ics.py example/test_calendar.yaml example/another_calendar.yaml > out.ics
+```
+
+
+
 ## Status
 
-Alpha, it works but may require code changes still to get around
-corner cases.
+Beta as of 2025, it works but may require code changes still to get
+around corner cases.  As of 2025 issues will probably be responded to.
 
 
 
-## See Also
+## See also
 
 * This directly uses https://github.com/scientific-python/yaml2ics as
   the yaml to ical generator - if you want to create your own build

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,61 @@
+# CC-0 (public domain)
+# but please link to the source so that people can more easily reuse
+# (if relevant)
+
+name: git-calendar
+description: Manage multiple branches in gh-pages
+
+inputs:
+  calendars:
+    description: 'Input calendar files'
+    default: 'calendars/*.yaml'
+  output_dir:
+    description: 'Output directory (default output/)'
+    default: 'output/'
+  extra_options:
+    description: 'extra options to git-calendar'
+    default: ''
+  index_file:
+    description: 'index.html summary file (default: index.html)'
+    default: index.html
+  html_body_file:
+    description: 'Like index.html, but only the part within body tags, for inclusion into other files'
+    default: ''
+  pages_deploy:
+    description: "Deploy to GitHub pages.  Use only if you don't have another pages deployment.  Default: true."
+    default: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      shell: bash
+      run: |
+        #pip install https://github.com/coderefinery/git-calendar/archives/main.zip
+        pip install ${{ github.action_path }}
+    - name: build
+      shell: bash
+      run: |
+        git-calendar\
+            ${{ inputs.calendars }} \
+            ${{ inputs.output_dir}} \
+            --edit-link=https://github.com/$GITHUB_REPOSITORY \
+            ${{ inputs.index_file && format('--index={0}', inputs.index_file) }} \
+            ${{ inputs.html_body_file && format('--html-body={0}', inputs.html_body_file) }} \
+            ${{ inputs.extra_options }}
+    - name: List outputs
+      shell: bash
+      run: |
+        find ${{ inputs.output_dir }} | sort
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: ${{ inputs.output_dir }}
+    - name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+      if: ${{ inputs.pages_deploy }}
+

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-git-calendar calendars/*.yaml -o out -i out/index.html -b out/body.html \
-    --timezone=Europe/Helsinki \
-    --timezone=Europe/Stockholm \
-    "$@"

--- a/calendars/test-include.yaml
+++ b/calendars/test-include.yaml
@@ -4,4 +4,3 @@ timezone: Europe/Helsinki
 include:
   - 'example.yaml'
   - 'https://coderefinery.github.io/calendar/workshops.ics'
-  - 'https://enccs.se/events-at-enccs/list/?shortcode=5210815c&ical=1'

--- a/git_calendar/templates/body.j2.html
+++ b/git_calendar/templates/body.j2.html
@@ -25,7 +25,7 @@
     )
     {%- endif %}
     {% if c.data.links -%}
-    ( {%- for href, text in c.data.links %}<a href="{{href}}">{{text}}</a>{% endfor %}{%if not loop.last%}, {% endif -%}
+    ( {%- for href, text in c.data.links %}<a href="{{href}}">{{text}}</a>{%if not loop.last%}, {% endif %}{% endfor -%}
     )
     {%- endif %}
   </li>

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -232,6 +232,9 @@ def files_to_events(files: list, dirname: str = "") -> (ics.Calendar, str):
         # If it is a raw ICS file
         if isinstance(f, str) and f.endswith(".ics"):
             calendar = ics.Calendar(open(os.path.join(dirname, f)))
+            #for event in calendar.events:
+                #print(f"INCLUDED: {f}")
+                #event.extra.append(ics.ContentLine(name='x-yaml2ics-source', value=str(f)))
             all_events.extend(calendar.events)
             continue
 

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -191,7 +191,7 @@ def gather_files(files: list, dirname: str = "") -> list:
     temporary_files = []
     for f in files:
         if isinstance(f, str) and f.startswith("http"):
-            print(f"Downloading {f}", flush=True)
+            print(f"Downloading {f} -> ...", flush=True)
             # This is an address on the web, so download it.
             with urllib.request.urlopen(f) as response:
                 headers = response.info()
@@ -204,10 +204,11 @@ def gather_files(files: list, dirname: str = "") -> list:
                 else:
                     # We will assume, that the Last bit of the URL is the filename
                     filename = f.split("/")[-1]
-                filetype = filename.split(".")[-1]
+                filename, filetype = os.path.splitext(filename)
                 with tempfile.NamedTemporaryFile(
-                    suffix="." + filetype, dir=dirname, delete=False
+                    prefix='tmp.'+filename, suffix=filetype, dir=dirname, delete=False
                 ) as temp_file:
+                    print(f"... -> {os.path.basename(temp_file.name)}", flush=True)
                     temp_file.write(response.read())
                     # we could probably also use the file itself, but I would like to be able to close it properly here.
                     collected_files.append(os.path.basename(temp_file.name))
@@ -227,6 +228,7 @@ def files_to_events(files: list, dirname: str = "") -> (ics.Calendar, str):
     print(files)
     print(dirname)
     for f in processed_files:
+        print(f"Processing {f}")
         # If it is a raw ICS file
         if isinstance(f, str) and f.endswith(".ics"):
             calendar = ics.Calendar(open(os.path.join(dirname, f)))

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -224,9 +224,9 @@ def files_to_events(files: list, dirname: str = "") -> (ics.Calendar, str):
     all_events = []
     name = None
     processed_files, temporary_files = gather_files(files, dirname=dirname)
-    print(processed_files)
-    print(files)
-    print(dirname)
+    #print(processed_files)
+    #print(files)
+    #print(dirname)
     for f in processed_files:
         print(f"Processing {f}")
         # If it is a raw ICS file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,16 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = [
-    #"yaml2ics",
-    "yaml2ics @ https://github.com/scientific-python/yaml2ics/archive/refs/heads/main.zip",
+    #"yaml2ics",  # now vendored
+    #"yaml2ics @ https://github.com/scientific-python/yaml2ics/archive/refs/heads/main.zip",
     "python-dateutil",
     "jinja2",
     "mutt-ics",
     "pyyaml",
     "markdown-it-py",
-    # TODO: how to install from github here?  Then remove this
-    # from requirements.txt
-    "ics @ https://github.com/ics-py/ics-py/archive/refs/heads/main.zip",
+    # There is some new unreleased ics-py feature needed.  As of 2025,
+    # last release was in 2022.
+    "ics @ https://github.com/ics-py/ics-py/archive/3b7d072.zip",  # main probably works too
 ]
 
 [project.scripts]


### PR DESCRIPTION
This is a big revision that includes many things.  Sorry, it was too much to separate out.  Main things:

- Slight updates to command line parameters (not backwards compatible)
- Add action.yml so that the action can be directly used in workflows.
- Fully go in to `git-calendar` command line usage.
- Various other small improvements

This shouldn't break compatibility since every other calendar site has git-calendar vendored.  Emphasis on "should"...